### PR TITLE
Text outline: thinner outline

### DIFF
--- a/src/features/cardEditor/cardStyles/components/fields/SvgHelpers/index.tsx
+++ b/src/features/cardEditor/cardStyles/components/fields/SvgHelpers/index.tsx
@@ -12,7 +12,7 @@ const SvgHelpers: FC = () => (
           in="SourceAlpha"
           result="MORPH"
           operator="dilate"
-          radius="2"
+          radius="1.5"
         />
         <feColorMatrix
           in="MORPH"
@@ -30,7 +30,7 @@ const SvgHelpers: FC = () => (
           in="SourceAlpha"
           result="MORPH"
           operator="dilate"
-          radius="2"
+          radius="1.5"
         />
         <feColorMatrix
           in="MORPH"


### PR DESCRIPTION
This is a small tweak to the text outline rendering. It makes the outline a little bit thinner to more closely match the physical cards.

Example:

![Charizard (1)](https://user-images.githubusercontent.com/3681/192119283-724f9ce4-70a0-4519-926a-19866ce30d78.png)


Benefits:

- Thinner text outline.

Downsides:

- No downsides compared to the current state (that I can see), but not as close a match to the physical cards as the other potential PRs I made (https://github.com/lvandernoll/pokecardmaker.net/pull/69, https://github.com/lvandernoll/pokecardmaker.net/pull/70)